### PR TITLE
Updated parse_soup() to get attributes correctly from new Kattis website

### DIFF
--- a/kattis_download/main.py
+++ b/kattis_download/main.py
@@ -36,19 +36,19 @@ def parse_soup(soup: BeautifulSoup) -> dict:
     # Store the actual title of the problem
     p["title"] = soup.find("h1").text
 
-    # Nested "sidebar-info" divs; recursively move inwards until at deepest
-    sidebar = soup.find("div", {"class": "sidebar-info"})
-    while sidebar.find("div", {"class": "sidebar-info"}):
-        sidebar = sidebar.find("div", {"class": "sidebar-info"})
-
-    # Last level deep has 2, the first is the buttons, second is problem data
-    sidebar = sidebar.find_next_sibling("div")
-
-    # Take the value in each attribute, ignore first (ID)
-    attributes = [p.text.split(":")[1].strip() for p in sidebar.findChildren("p")][1:]
-    attribute_keys = ["cpu", "memory", "difficulty"]
-    for _ in range(len(attribute_keys)):
-        p[attribute_keys[_]] = attributes[_]
+    # Get the cpu time limit, memory limit, and difficulty of the problem 
+    metadata = soup.find_all("div", {"class":"metadata_list-item"})
+    tag_attr_name_mapping = {'cpu_limit':'cpu',
+                     'mem_limit':'memory', 
+                     'difficulty':'difficulty'}
+    for item in metadata:
+        try:
+            data_name = item.attrs['data-name'].split('-')[1]
+            if data_name in tag_attr_name_mapping:
+                children = item.findChildren('span')
+                p[tag_attr_name_mapping[data_name]] = children[-1].text
+        except:
+            pass
 
     # Find all tables with sample data in the Soup
     tables = soup.findAll("table", {"summary": "sample data"})


### PR DESCRIPTION
The [Kattis website](https://open.kattis.com/problems/ ) has changed since the code was written, and the  "Metadata" tab has now replaced the old sidebar that used to contain problem metadata (such as CPU Time Limit, Memory Limit, etc.). 

Here is a screenshot showing the new website layout:

<img width="1176" alt="Screen Shot 2023-05-29 at 5 02 11 AM" src="https://github.com/bradendubois/kattis-problem-setup/assets/62921939/aab04feb-8c36-4c6b-8435-19cb32998111">

I have updated the web scraping code in the `parse_soup()` function in kattis_download/main.py to get the CPU time limit, memory limit, and problem difficulty correctly from the updated Kattis website. The rest of the code is the same.

It was a simple fix, but a useful one I hope :) 